### PR TITLE
macOS .app packaging, cross-platform Dirs, -Duse-cwd

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -38,6 +38,19 @@ pub const Config = struct {
     /// levels for the texture. Off by default since the extra VRAM cost
     /// only pays off for textures sampled at a wide range of distances.
     psp_mipmaps: bool = false,
+    /// When true, `Core.paths.resolve` returns CWD for both resources
+    /// and data, bypassing the platform-specific layout (.app Resources
+    /// on mac, APPDATA on Windows, XDG on Linux).
+    ///
+    /// Useful for:
+    ///   - `zig build run-game` iterations where assets sit alongside
+    ///     zig-out/bin/ and you don't want state cluttering your home
+    ///     dir.
+    ///   - CI jobs that compare runtime output against a known working
+    ///     directory.
+    ///   - Debug builds of unpackaged binaries on macOS, where resources
+    ///     aren't inside a .app yet.
+    use_cwd: bool = false,
 
     pub fn resolve(target: std.Build.ResolvedTarget, overrides: Overrides) Config {
         const plat: Platform = switch (target.result.os.tag) {
@@ -62,6 +75,7 @@ pub const Config = struct {
             .gfx = overrides.gfx orelse default_gfx,
             .psp_display_mode = overrides.psp_display_mode orelse .rgba8888,
             .psp_mipmaps = overrides.psp_mipmaps orelse false,
+            .use_cwd = overrides.use_cwd orelse false,
         };
     }
 
@@ -69,6 +83,7 @@ pub const Config = struct {
         gfx: ?Gfx = null,
         psp_display_mode: ?PspDisplayMode = null,
         psp_mipmaps: ?bool = null,
+        use_cwd: ?bool = null,
     };
 };
 
@@ -90,6 +105,31 @@ pub const HeadlessOptions = struct {
 pub const ShaderPaths = struct {
     slang: std.Build.LazyPath,
 };
+
+// Cached per-build user options. b.option panics on second declaration, so
+// these getters declare once and memoize. Accessed from both addGame (for
+// linking) and exportArtifact (for bundle packaging). Module-level mutable
+// state is safe here: build.zig is single-threaded per invocation and
+// build.zig instances don't live across invocations.
+var molten_vk_path_cached: ?[]const u8 = null;
+fn macosMoltenVkPath(b: *std.Build) []const u8 {
+    if (molten_vk_path_cached) |p| return p;
+    const p = b.option([]const u8, "molten-vk-path",
+        "macOS: directory containing libMoltenVK.dylib (default: $(brew --prefix molten-vk)/lib)") orelse
+        "/opt/homebrew/opt/molten-vk/lib";
+    molten_vk_path_cached = p;
+    return p;
+}
+
+var glfw_path_cached: ?[]const u8 = null;
+fn macosGlfwPath(b: *std.Build) []const u8 {
+    if (glfw_path_cached) |p| return p;
+    const p = b.option([]const u8, "glfw-path",
+        "macOS: directory containing libglfw.3.dylib (default: $(brew --prefix glfw)/lib)") orelse
+        "/opt/homebrew/opt/glfw/lib";
+    glfw_path_cached = p;
+    return p;
+}
 
 /// Creates an executable with the Aether engine module and all platform
 /// dependencies wired up. Returns the compile step so the caller can
@@ -161,8 +201,19 @@ pub fn addGame(owner: *std.Build, b: *std.Build, opts: GameOptions) *std.Build.S
         mod.linkLibrary(zaudio_dep.artifact("miniaudio"));
 
         if (opts.target.result.os.tag == .macos) {
-            mod.linkSystemLibrary("vulkan", .{});
+            // Link MoltenVK directly as the Vulkan ICD — no loader. Feeds
+            // its vkGetInstanceProcAddr into GLFW via glfwInitVulkanLoader
+            // in platform/glfw/surface.zig so GLFW doesn't dlopen libvulkan
+            // (which is brittle across brew/SDK installs).
+            mod.addLibraryPath(.{ .cwd_relative = macosMoltenVkPath(b) });
+            mod.addLibraryPath(.{ .cwd_relative = macosGlfwPath(b) });
+            mod.linkSystemLibrary("MoltenVK", .{});
             mod.linkSystemLibrary("glfw3", .{});
+
+            // rpath for the .app bundle layout: exe in Contents/MacOS/, dylibs
+            // in Contents/Frameworks/. Harmless when running bare out of
+            // zig-out/bin (only consulted after absolute paths fail).
+            mod.addRPathSpecial("@executable_path/../Frameworks");
 
             if (owner.lazyDependency("system_sdk", .{})) |system_sdk| {
                 mod.addFrameworkPath(system_sdk.path("macos12/System/Library/Frameworks"));
@@ -284,7 +335,8 @@ fn addSlangStep(b: *std.Build, slangc: ?std.Build.LazyPath, args: []const []cons
 }
 
 pub const ExportOptions = struct {
-    /// PSP: title shown on the XMB. Ignored on other platforms.
+    /// PSP/macOS: human-readable name shown to the OS (XMB title on PSP,
+    /// CFBundleName on macOS). Ignored elsewhere.
     title: []const u8 = "",
     /// PSP: subdirectory under zig-out/bin/ for EBOOT artifacts.
     /// Defaults to the executable name. Ignored on other platforms.
@@ -295,21 +347,192 @@ pub const ExportOptions = struct {
     pic0: ?std.Build.LazyPath = null,
     pic1: ?std.Build.LazyPath = null,
     snd0: ?std.Build.LazyPath = null,
+    /// macOS: reverse-DNS bundle identifier for Info.plist (CFBundleIdentifier).
+    /// Defaults to "com.aether.<exe-name>".
+    bundle_id: ?[]const u8 = null,
+    /// macOS: PNG icon to use for the bundle. Compiled to AppIcon.icns at
+    /// build time via `sips` + `iconutil` (mac-only tools, which is fine —
+    /// the .app branch only runs on mac builds). 1024×1024 PNG is ideal
+    /// since every other size downscales cleanly from that; smaller
+    /// sources are upscaled via bilinear, which is fine for placeholders.
+    icon_png: ?std.Build.LazyPath = null,
+    /// Files to install into the app bundle. On macOS they land under
+    /// `Contents/Resources/<name>`. On desktop non-macOS they are copied
+    /// alongside the exe in `zig-out/bin/`. Ignored on PSP.
+    resources: []const Resource = &.{},
+
+    pub const Resource = struct {
+        /// Source file to copy.
+        path: std.Build.LazyPath,
+        /// Destination name inside Resources/ (or alongside exe on non-mac).
+        name: []const u8,
+    };
 };
 
 /// Installs the game executable with platform-appropriate packaging.
-/// On desktop this calls `b.installArtifact`. On PSP this runs the
-/// ELF -> PRX -> SFO -> EBOOT.PBP pipeline via pspsdk.
+/// - PSP: ELF -> PRX -> SFO -> EBOOT.PBP pipeline.
+/// - macOS: produces a `<name>.app` bundle under `zig-out/bin/` with
+///   MoltenVK + glfw3 dylibs in `Contents/Frameworks/`, load-command
+///   paths rewritten to `@rpath`, and ad-hoc codesign applied.
+/// - Other desktop: plain `b.installArtifact`, plus any `opts.resources`
+///   copied alongside the exe.
 pub fn exportArtifact(owner: *std.Build, b: *std.Build, exe: *std.Build.Step.Compile, config: Config, opts: ExportOptions) void {
     if (config.platform == .psp) {
-        // Resolve pspsdk artifacts from `owner` (which has pspsdk in
-        // its dep tree), but run the pipeline on `b` so install steps
+        // Resolve pspsdk artifacts from `owner` (which has pspsdk in its
+        // dep tree), but run the pipeline on `b` so install steps
         // register on the downstream project's builder.
         const psp_dep = owner.dependency("pspsdk", .{});
         _ = pspEbootPipeline(b, exe, psp_dep, opts);
+    } else if (config.platform == .macos) {
+        macosAppBundle(b, exe, opts);
     } else {
         b.installArtifact(exe);
+        for (opts.resources) |res| {
+            const install_res = b.addInstallBinFile(res.path, res.name);
+            b.getInstallStep().dependOn(&install_res.step);
+        }
     }
+}
+
+/// Builds a `<exe.name>.app` directory under zig-out/bin/ with:
+///   Contents/MacOS/<exe>                   — patched load commands
+///   Contents/Frameworks/libMoltenVK.dylib  — id rewritten to @rpath
+///   Contents/Frameworks/libglfw.3.dylib    — id rewritten to @rpath
+///   Contents/Info.plist                    — minimum viable plist
+///   Contents/Resources/<name>              — opts.resources
+///
+/// After install, a post-install Run step invokes `codesign --force
+/// --sign -` on each leaf dylib, then the exe, then the bundle dir.
+/// --deep is intentionally avoided (deprecated, unreliable).
+fn macosAppBundle(b: *std.Build, exe: *std.Build.Step.Compile, opts: ExportOptions) void {
+    const molten_vk_dir = macosMoltenVkPath(b);
+    const glfw_dir = macosGlfwPath(b);
+
+    const app_name = b.fmt("{s}.app", .{exe.name});
+
+    // --- patch bundled dylibs: copy into cache, rewrite LC_ID_DYLIB -----
+    // Each Run step takes the brew dylib as an input and writes a patched
+    // copy to its own cache-managed output path, keeping zig's caching honest.
+    const patched_moltenvk = patchDylibId(
+        b,
+        .{ .cwd_relative = b.pathJoin(&.{ molten_vk_dir, "libMoltenVK.dylib" }) },
+        "libMoltenVK.dylib",
+    );
+    const patched_glfw = patchDylibId(
+        b,
+        .{ .cwd_relative = b.pathJoin(&.{ glfw_dir, "libglfw.3.dylib" }) },
+        "libglfw.3.dylib",
+    );
+
+    // --- patch exe load commands ---------------------------------------
+    const patched_exe = b.addSystemCommand(&.{ "sh", "-c",
+        "cp \"$1\" \"$2\" && " ++
+        "chmod +w \"$2\" && " ++
+        "install_name_tool " ++
+        "-change /opt/homebrew/opt/molten-vk/lib/libMoltenVK.dylib @rpath/libMoltenVK.dylib " ++
+        "-change /opt/homebrew/opt/glfw/lib/libglfw.3.dylib @rpath/libglfw.3.dylib " ++
+        "\"$2\"",
+        "sh",
+    });
+    patched_exe.addArtifactArg(exe);
+    const exe_out = patched_exe.addOutputFileArg(exe.name);
+
+    // --- icon: PNG -> .icns via sips + iconutil ------------------------
+    const icns_out: ?std.Build.LazyPath = if (opts.icon_png) |png| blk: {
+        const gen = b.addSystemCommand(&.{ "sh", "-c",
+            // mktemp a scratch .iconset dir, sips-resize the source PNG into
+            // the canonical slot names, then iconutil-pack. Cleanup is
+            // best-effort — on failure the tmpdir leaks, but it's under /tmp.
+            \\set -euo pipefail
+            \\IN="$1"; OUT="$2"
+            \\T=$(mktemp -d -t aether_icns.XXXXXX)
+            \\trap 'rm -rf "$T"' EXIT
+            \\ISET="$T/AppIcon.iconset"; mkdir -p "$ISET"
+            \\for spec in \
+            \\  "16 icon_16x16.png" "32 icon_16x16@2x.png" \
+            \\  "32 icon_32x32.png" "64 icon_32x32@2x.png" \
+            \\  "128 icon_128x128.png" "256 icon_128x128@2x.png" \
+            \\  "256 icon_256x256.png" "512 icon_256x256@2x.png" \
+            \\  "512 icon_512x512.png" "1024 icon_512x512@2x.png"; do
+            \\  set -- $spec; sz=$1; name=$2
+            \\  sips -z "$sz" "$sz" "$IN" --out "$ISET/$name" >/dev/null
+            \\done
+            \\iconutil -c icns "$ISET" -o "$OUT"
+            ,
+            "sh",
+        });
+        gen.addFileArg(png);
+        break :blk gen.addOutputFileArg("AppIcon.icns");
+    } else null;
+
+    // --- Info.plist ----------------------------------------------------
+    const bundle_id = opts.bundle_id orelse b.fmt("com.aether.{s}", .{exe.name});
+    const bundle_name = if (opts.title.len > 0) opts.title else exe.name;
+    const icon_key = if (icns_out != null)
+        "<key>CFBundleIconFile</key><string>AppIcon</string>"
+    else
+        "";
+    const info_plist = b.fmt(
+        \\<?xml version="1.0" encoding="UTF-8"?>
+        \\<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        \\<plist version="1.0"><dict>
+        \\  <key>CFBundleExecutable</key><string>{s}</string>
+        \\  <key>CFBundleIdentifier</key><string>{s}</string>
+        \\  <key>CFBundleName</key><string>{s}</string>
+        \\  <key>CFBundlePackageType</key><string>APPL</string>
+        \\  <key>CFBundleShortVersionString</key><string>0.0.0</string>
+        \\  <key>CFBundleVersion</key><string>0</string>
+        \\  <key>LSMinimumSystemVersion</key><string>11.0</string>
+        \\  <key>NSHighResolutionCapable</key><true/>
+        \\  {s}
+        \\</dict></plist>
+        \\
+    , .{ exe.name, bundle_id, bundle_name, icon_key });
+
+    // --- assemble the .app tree in a WriteFiles output -----------------
+    const app_tree = b.addWriteFiles();
+    _ = app_tree.addCopyFile(exe_out, b.fmt("Contents/MacOS/{s}", .{exe.name}));
+    _ = app_tree.addCopyFile(patched_moltenvk, "Contents/Frameworks/libMoltenVK.dylib");
+    _ = app_tree.addCopyFile(patched_glfw, "Contents/Frameworks/libglfw.3.dylib");
+    _ = app_tree.add("Contents/Info.plist", info_plist);
+    if (icns_out) |icns| _ = app_tree.addCopyFile(icns, "Contents/Resources/AppIcon.icns");
+    for (opts.resources) |res| {
+        _ = app_tree.addCopyFile(res.path, b.fmt("Contents/Resources/{s}", .{res.name}));
+    }
+
+    // --- install the tree under zig-out/bin/<exe>.app ------------------
+    const install = b.addInstallDirectory(.{
+        .source_dir = app_tree.getDirectory(),
+        .install_dir = .bin,
+        .install_subdir = app_name,
+    });
+    b.getInstallStep().dependOn(&install.step);
+
+    // --- ad-hoc codesign (post-install, operates on zig-out paths) -----
+    // Must run AFTER install_name_tool is long done. Sign leaves first,
+    // then the exe, then the bundle dir — avoids --deep which is
+    // deprecated and unreliable.
+    const bundle_path = b.getInstallPath(.bin, app_name);
+    const sign = b.addSystemCommand(&.{ "sh", "-c", b.fmt(
+        "codesign --force --sign - \"{s}/Contents/Frameworks/libMoltenVK.dylib\" && " ++
+        "codesign --force --sign - \"{s}/Contents/Frameworks/libglfw.3.dylib\" && " ++
+        "codesign --force --sign - \"{s}/Contents/MacOS/{s}\" && " ++
+        "codesign --force --sign - \"{s}\"",
+        .{ bundle_path, bundle_path, bundle_path, exe.name, bundle_path },
+    ) });
+    sign.step.dependOn(&install.step);
+    b.getInstallStep().dependOn(&sign.step);
+}
+
+/// Copies a dylib into the build cache and rewrites its LC_ID_DYLIB to
+/// `@rpath/<basename>` so it can be loaded from `Contents/Frameworks/`.
+fn patchDylibId(b: *std.Build, src: std.Build.LazyPath, basename: []const u8) std.Build.LazyPath {
+    const patch = b.addSystemCommand(&.{ "sh", "-c", b.fmt(
+        "cp \"$1\" \"$2\" && chmod +w \"$2\" && install_name_tool -id @rpath/{s} \"$2\"",
+        .{basename},
+    ), "sh" });
+    patch.addFileArg(src);
+    return patch.addOutputFileArg(basename);
 }
 
 /// Runs the ELF -> PRX -> SFO -> EBOOT.PBP pipeline. Resolves tool
@@ -428,6 +651,7 @@ pub fn build(b: *std.Build) void {
         .gfx = b.option(Gfx, "gfx", "Graphics backend override (default: auto-detect from target)"),
         .psp_display_mode = b.option(PspDisplayMode, "psp-display", "PSP display mode: rgba8888 (32-bit, default) or rgb565 (16-bit)"),
         .psp_mipmaps = b.option(bool, "psp-mipmaps", "PSP: generate mip levels for VRAM-resident textures (default: false)"),
+        .use_cwd = b.option(bool, "use-cwd", "Force resources+data dirs to CWD (debug/CI convenience; default: false)"),
     };
 
     const config = Config.resolve(target, overrides);

--- a/src/core/core.zig
+++ b/src/core/core.zig
@@ -1,3 +1,4 @@
 pub const state_machine = @import("state_machine.zig");
 pub const State = @import("State.zig");
 pub const input = @import("input.zig");
+pub const paths = @import("paths.zig");

--- a/src/core/paths.zig
+++ b/src/core/paths.zig
@@ -1,0 +1,189 @@
+//! Cross-platform per-app directories.
+//!
+//! Games write two kinds of files that want different locations:
+//!
+//!   * **Resources** — read-only assets shipped with the app (pack.zip,
+//!     embedded shaders, icons). On macOS these live inside
+//!     `<Bundle>.app/Contents/Resources/`; on desktop Linux/Windows they
+//!     sit alongside the exe; on PSP they sit at CWD.
+//!
+//!   * **Data** — user-writable persistent state (world saves, logs,
+//!     config, user-installed texture packs). OS-conventional locations
+//!     apply here: `~/Library/Application Support/<app>` on macOS,
+//!     `%APPDATA%\<app>` on Windows, `$XDG_DATA_HOME/<app>` on Linux.
+//!
+//! Both are exposed as open `std.Io.Dir` handles owned by the engine for
+//! its lifetime. Callers pass the appropriate Dir into file-open APIs
+//! (e.g. `dirs.resources.openFile(io, "pack.zip", .{})`) instead of
+//! using `Io.Dir.cwd()`, which was the prior convention and broke when
+//! CWD was not the app root (Finder-launched .app has CWD=/).
+//!
+//! Env-var access is routed through the caller-supplied
+//! `std.process.Environ.Map`; this module never touches `std.c`,
+//! `std.os`, or `std.posix` — paths are an engine-boundary concern but
+//! per project style guide they go through `std.Io` / `std.process`.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const options = @import("options");
+
+const Io = std.Io;
+
+/// Engine-owned directory handles. Cleared via `close()` at engine shutdown.
+pub const Dirs = struct {
+    /// Read-only assets shipped with the app. On platforms where the
+    /// concept doesn't apply, points at CWD.
+    resources: Io.Dir,
+    /// User-writable persistent state. On platforms where the concept
+    /// doesn't apply, points at CWD (same handle as `resources`).
+    data: Io.Dir,
+
+    pub fn close(self: *Dirs, io: Io) void {
+        // On CWD-fallback platforms resources and data are the same
+        // handle; closing a cwd handle is a no-op regardless.
+        self.resources.close(io);
+        self.data.close(io);
+    }
+};
+
+pub const Error = error{
+    /// `HOME` (mac/linux) env var missing — no way to derive user data dir.
+    MissingHome,
+    /// `APPDATA` (windows) env var missing.
+    MissingAppData,
+    /// Constructed path would exceed `Io.Dir.max_path_bytes`.
+    PathTooLong,
+} ||
+    Io.Cancelable ||
+    Io.UnexpectedError ||
+    Io.Dir.OpenError ||
+    Io.Dir.CreateDirPathOpenError ||
+    std.process.ExecutablePathError;
+
+/// Resolve per-app directories for the current platform.
+///
+/// `app_name` is used as the leaf directory name under the per-user
+/// data root (e.g. `~/Library/Application Support/<app_name>/`). The
+/// data directory is created if missing.
+pub fn resolve(
+    io: Io,
+    environ_map: *const std.process.Environ.Map,
+    app_name: []const u8,
+) Error!Dirs {
+    std.debug.assert(app_name.len > 0);
+
+    // Build-time `-Duse-cwd=true` short-circuits the platform layout and
+    // points both dirs at CWD. Handy for `zig build run-game` iteration
+    // and debug/CI builds where state co-located with the binary is a
+    // feature, not a bug.
+    if (options.config.use_cwd) {
+        return .{ .resources = Io.Dir.cwd(), .data = Io.Dir.cwd() };
+    }
+
+    return switch (builtin.os.tag) {
+        .macos => resolve_macos(io, environ_map, app_name),
+        .windows => resolve_windows(io, environ_map, app_name),
+        .linux => resolve_linux(io, environ_map, app_name),
+        // PSP: both dirs collapse to CWD. The EBOOT and its siblings all
+        // live under `ms0:/PSP/GAME/<id>/`; the runtime sets CWD there
+        // before main. No separation to enforce.
+        //
+        // Vita/others: placeholder until those ports land. Same CWD
+        // fallback keeps early bring-up builds working with zero
+        // platform-specific code.
+        else => .{ .resources = Io.Dir.cwd(), .data = Io.Dir.cwd() },
+    };
+}
+
+// -- macOS --------------------------------------------------------------------
+
+fn resolve_macos(
+    io: Io,
+    environ_map: *const std.process.Environ.Map,
+    app_name: []const u8,
+) Error!Dirs {
+    var exe_dir_buf: [Io.Dir.max_path_bytes]u8 = undefined;
+    const exe_dir_len = try std.process.executableDirPath(io, &exe_dir_buf);
+    const exe_dir = exe_dir_buf[0..exe_dir_len];
+
+    const resources = try open_macos_resources(io, exe_dir);
+
+    const home = environ_map.get("HOME") orelse return error.MissingHome;
+    var data_buf: [Io.Dir.max_path_bytes]u8 = undefined;
+    const data_path = std.fmt.bufPrint(
+        &data_buf,
+        "{s}/Library/Application Support/{s}",
+        .{ home, app_name },
+    ) catch return error.PathTooLong;
+    const data = try Io.Dir.cwd().createDirPathOpen(io, data_path, .{ .open_options = .{ .iterate = true } });
+
+    return .{ .resources = resources, .data = data };
+}
+
+/// Resources dir is `<Bundle>.app/Contents/Resources/` when launched from
+/// an .app bundle (exe is at `.../<Bundle>.app/Contents/MacOS/<exe>`).
+/// For `zig build run-game` / a loose exe layout, fall back to the exe's
+/// dir so dev builds still find CWD-style resources.
+fn open_macos_resources(io: Io, exe_dir: []const u8) Error!Io.Dir {
+    const macos_suffix = "/Contents/MacOS";
+    const bundle_ok = std.mem.endsWith(u8, exe_dir, macos_suffix) and
+        exe_dir.len > macos_suffix.len;
+
+    if (bundle_ok) {
+        const contents = exe_dir[0 .. exe_dir.len - "/MacOS".len];
+        if (std.fs.path.dirname(contents)) |app_dir| {
+            if (std.mem.endsWith(u8, app_dir, ".app")) {
+                var res_buf: [Io.Dir.max_path_bytes]u8 = undefined;
+                const res_path = std.fmt.bufPrint(&res_buf, "{s}/Resources", .{contents}) catch
+                    return error.PathTooLong;
+                return Io.Dir.openDirAbsolute(io, res_path, .{});
+            }
+        }
+    }
+    return Io.Dir.openDirAbsolute(io, exe_dir, .{});
+}
+
+// -- Windows ------------------------------------------------------------------
+
+fn resolve_windows(
+    io: Io,
+    environ_map: *const std.process.Environ.Map,
+    app_name: []const u8,
+) Error!Dirs {
+    var exe_dir_buf: [Io.Dir.max_path_bytes]u8 = undefined;
+    const exe_dir_len = try std.process.executableDirPath(io, &exe_dir_buf);
+    const resources = try Io.Dir.openDirAbsolute(io, exe_dir_buf[0..exe_dir_len], .{});
+
+    const appdata = environ_map.get("APPDATA") orelse return error.MissingAppData;
+    var data_buf: [Io.Dir.max_path_bytes]u8 = undefined;
+    const data_path = std.fmt.bufPrint(&data_buf, "{s}\\{s}", .{ appdata, app_name }) catch
+        return error.PathTooLong;
+    const data = try Io.Dir.cwd().createDirPathOpen(io, data_path, .{ .open_options = .{ .iterate = true } });
+    return .{ .resources = resources, .data = data };
+}
+
+// -- Linux --------------------------------------------------------------------
+
+fn resolve_linux(
+    io: Io,
+    environ_map: *const std.process.Environ.Map,
+    app_name: []const u8,
+) Error!Dirs {
+    var exe_dir_buf: [Io.Dir.max_path_bytes]u8 = undefined;
+    const exe_dir_len = try std.process.executableDirPath(io, &exe_dir_buf);
+    const resources = try Io.Dir.openDirAbsolute(io, exe_dir_buf[0..exe_dir_len], .{});
+
+    // XDG Base Directory Specification: prefer $XDG_DATA_HOME, fall back to
+    // $HOME/.local/share. Both branches format into the same stack buffer.
+    var data_buf: [Io.Dir.max_path_bytes]u8 = undefined;
+    const data_path = if (environ_map.get("XDG_DATA_HOME")) |xdg|
+        std.fmt.bufPrint(&data_buf, "{s}/{s}", .{ xdg, app_name }) catch
+            return error.PathTooLong
+    else blk: {
+        const home = environ_map.get("HOME") orelse return error.MissingHome;
+        break :blk std.fmt.bufPrint(&data_buf, "{s}/.local/share/{s}", .{ home, app_name }) catch
+            return error.PathTooLong;
+    };
+    const data = try Io.Dir.cwd().createDirPathOpen(io, data_path, .{ .open_options = .{ .iterate = true } });
+    return .{ .resources = resources, .data = data };
+}

--- a/src/engine.zig
+++ b/src/engine.zig
@@ -88,6 +88,7 @@ pub const Engine = struct {
     running: bool,
     vsync: bool,
     state: *const Core.State,
+    dirs: Core.paths.Dirs,
 
     pub const Config = struct {
         memory: MemoryConfig,
@@ -97,13 +98,30 @@ pub const Engine = struct {
         fullscreen: bool = false,
         vsync: bool = true,
         resizable: bool = false,
+        /// Leaf directory name under the per-user data root (e.g.
+        /// `~/Library/Application Support/<app_name>/`). Defaults to
+        /// `title` so single-word titles just work; override when the
+        /// title contains characters you don't want in a filesystem path.
+        app_name: ?[]const u8 = null,
     };
 
     /// Initializes the engine in place. `self` must live at a stable address
     /// for the lifetime of the program — the allocators produced by
     /// `allocator(p)` each carry a pointer into `self.trackers`, so moving or
     /// copying an initialized `Engine` will leave those pointers dangling.
-    pub fn init(self: *Engine, sys_io: std.Io, mem: []u8, config: Config, state: *const Core.State) !void {
+    ///
+    /// `environ_map` comes from `std.process.Init.environ_map` and is used
+    /// only during init to resolve platform-specific data directories
+    /// (HOME/APPDATA/XDG_DATA_HOME). The engine does not retain a
+    /// reference.
+    pub fn init(
+        self: *Engine,
+        sys_io: std.Io,
+        environ_map: *const std.process.Environ.Map,
+        mem: []u8,
+        config: Config,
+        state: *const Core.State,
+    ) !void {
         assert(config.memory.total() <= mem.len);
 
         self.io = sys_io;
@@ -123,7 +141,12 @@ pub const Engine = struct {
             };
         }
 
-        try logger.init(sys_io);
+        // Dirs must resolve BEFORE logger (which opens a log file in the
+        // data dir) and BEFORE Platform.init (which may read resources).
+        const app_name = config.app_name orelse config.title;
+        self.dirs = try Core.paths.resolve(sys_io, environ_map, app_name);
+
+        try logger.init(sys_io, self.dirs.data);
 
         try Platform.init(self, config.width, config.height, config.title, config.fullscreen, config.vsync, config.resizable);
         try Rendering.Texture.init_defaults(self.allocator(.render));
@@ -137,6 +160,7 @@ pub const Engine = struct {
         Rendering.Texture.Default.deinit(self.allocator(.render));
         Platform.deinit();
         logger.deinit(self.io);
+        self.dirs.close(self.io);
     }
 
     pub fn allocator(self: *Engine, p: Pool) std.mem.Allocator {

--- a/src/platform/glfw/surface.zig
+++ b/src/platform/glfw/surface.zig
@@ -1,9 +1,24 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const Util = @import("../../util/util.zig");
 const glfw = @import("glfw");
 
 const Self = @This();
 const api = @import("options").config.gfx;
+
+// macOS: we link MoltenVK directly as the Vulkan ICD and skip the Vulkan
+// loader entirely. Feed MoltenVK's vkGetInstanceProcAddr to GLFW before
+// glfwInit so glfwVulkanSupported doesn't dlopen("libvulkan.1.dylib") —
+// that name lookup hits DYLD_FALLBACK_LIBRARY_PATH (which doesn't include
+// /opt/homebrew/...) and either fails outright or picks up a stale
+// LunarG SDK loader from /usr/local/lib. Both are common and produce a
+// misleading `VulkanNotSupported` error.
+//
+// These externs resolve at link time because MoltenVK and glfw3 are both
+// linked into the exe (see Aether/build.zig macOS branch).
+const VulkanProc = *const fn () callconv(.c) void;
+extern fn vkGetInstanceProcAddr(instance: ?*anyopaque, name: [*:0]const u8) callconv(.c) ?VulkanProc;
+extern fn glfwInitVulkanLoader(loader: *const fn (?*anyopaque, [*:0]const u8) callconv(.c) ?VulkanProc) void;
 
 alloc: std.mem.Allocator,
 window: *glfw.Window = undefined,
@@ -23,6 +38,12 @@ pub var on_resize: ?*const fn () void = null;
 
 pub fn init(self: *Self, width: u32, height: u32, title: [:0]const u8, fullscreen: bool, sync: bool, resizable: bool) anyerror!void {
     self.active_joystick = 0;
+
+    // See extern decls above — bypass GLFW's libvulkan.1.dylib dlopen on macOS.
+    // Must run BEFORE glfw.init() per GLFW 3.4 API contract.
+    if (builtin.target.os.tag == .macos and api == .vulkan) {
+        glfwInitVulkanLoader(&vkGetInstanceProcAddr);
+    }
 
     glfw.initHint(glfw.JoystickHatButtons, 1);
 

--- a/src/platform/glfw/vulkan/context.zig
+++ b/src/platform/glfw/vulkan/context.zig
@@ -20,8 +20,11 @@ const Device = vk.DeviceProxy;
 // pipeline. See set_alpha_blend in vulkan_gfx.zig for the callsite behavior.
 const is_macos = builtin.target.os.tag == .macos;
 
+// Portability-subset is mandatory on MoltenVK per the Vulkan Portability
+// spec: if the device advertises VK_KHR_portability_subset (MoltenVK does)
+// the app must enable it at vkCreateDevice.
 const required_device_extensions = if (is_macos)
-    [_][*:0]const u8{ vk.extensions.khr_swapchain.name, vk.extensions.khr_synchronization_2.name, vk.extensions.khr_create_renderpass_2.name }
+    [_][*:0]const u8{ vk.extensions.khr_swapchain.name, vk.extensions.khr_synchronization_2.name, vk.extensions.khr_create_renderpass_2.name, vk.extensions.khr_portability_subset.name }
 else
     [_][*:0]const u8{ vk.extensions.khr_swapchain.name, vk.extensions.khr_synchronization_2.name, vk.extensions.khr_create_renderpass_2.name, vk.extensions.ext_extended_dynamic_state_3.name };
 
@@ -55,7 +58,15 @@ fn create_instance(self: *Self, name: [:0]const u8) !void {
         try extension_names.append(self.allocator, vk.extensions.ext_debug_utils.name);
     }
 
-    try extension_names.append(self.allocator, vk.extensions.khr_portability_enumeration.name);
+    // khr_portability_enumeration and the matching enumerate_portability
+    // instance flag are LOADER-implemented. On macOS we link MoltenVK
+    // directly (no loader) so requesting either fails with
+    // VK_ERROR_EXTENSION_NOT_PRESENT. Skip on mac — we don't need to tell
+    // the loader "include portability ICDs" when MoltenVK is the only
+    // thing we talk to.
+    if (!is_macos) {
+        try extension_names.append(self.allocator, vk.extensions.khr_portability_enumeration.name);
+    }
     try extension_names.append(self.allocator, vk.extensions.khr_get_physical_device_properties_2.name);
 
     // Get required GLFW extensions
@@ -74,7 +85,7 @@ fn create_instance(self: *Self, name: [:0]const u8) !void {
         },
         .enabled_extension_count = @intCast(extension_names.items.len),
         .pp_enabled_extension_names = extension_names.items.ptr,
-        .flags = .{ .enumerate_portability_bit_khr = true },
+        .flags = if (is_macos) .{} else .{ .enumerate_portability_bit_khr = true },
     };
 
     // With validation layers?

--- a/src/rendering/texture.zig
+++ b/src/rendering/texture.zig
@@ -61,10 +61,15 @@ pub fn init_defaults(alloc: std.mem.Allocator) !void {
     Default = try load_from_data(alloc, 4, 4, &pixels);
 }
 
-/// Loads a PNG from `path` into GPU memory.
+/// Loads a PNG from `path` (resolved against `dir`) into GPU memory.
 /// The decoded pixel buffer lives in the provided allocator.
-pub fn load(io: std.Io, alloc: std.mem.Allocator, path: []const u8) !Texture {
-    var file = try std.Io.Dir.cwd().openFile(io, path, .{});
+///
+/// Callers pass `engine.dirs.resources` for bundled textures or
+/// `engine.dirs.data` for user-provided ones. Do not use
+/// `std.Io.Dir.cwd()` — CWD is not guaranteed to be the app root
+/// (Finder-launched `.app` bundles give CWD = `/`).
+pub fn load(io: std.Io, dir: std.Io.Dir, alloc: std.mem.Allocator, path: []const u8) !Texture {
+    var file = try dir.openFile(io, path, .{});
     defer file.close(io);
 
     var temp: [4096]u8 = undefined;

--- a/src/util/logger.zig
+++ b/src/util/logger.zig
@@ -6,9 +6,17 @@ var file_log: std.Io.File = undefined;
 var file_writer: std.Io.File.Writer = undefined;
 var writer: *std.Io.Writer = undefined;
 
-pub fn init(io: std.Io) !void {
-    const log_path = if (builtin.os.tag == .psp) "ms0:/aether.log" else "aether.log";
-    file_log = try std.Io.Dir.cwd().createFile(io, log_path, .{ .truncate = true });
+/// PSP has no per-user data dir concept; the log sits at CWD (which is
+/// where the EBOOT lives) regardless of what `data_dir` points at. Every
+/// other platform routes through the engine-resolved data dir so
+/// Finder-launched `.app` bundles don't try to write into read-only
+/// bundle internals.
+pub fn init(io: std.Io, data_dir: std.Io.Dir) !void {
+    if (builtin.os.tag == .psp) {
+        file_log = try std.Io.Dir.cwd().createFile(io, "ms0:/aether.log", .{ .truncate = true });
+    } else {
+        file_log = try data_dir.createFile(io, "aether.log", .{ .truncate = true });
+    }
     file_writer = file_log.writer(io, &log_buffer);
     writer = &file_writer.interface;
 }

--- a/test/main.zig
+++ b/test/main.zig
@@ -85,7 +85,7 @@ const MyState = struct {
         self.mesh = try MyMesh.new(render, pipeline);
         self.transform = Rendering.Transform.new();
 
-        self.texture = try Rendering.Texture.load(engine.io, render, "test.png");
+        self.texture = try Rendering.Texture.load(engine.io, engine.dirs.resources, render, "test.png");
         try self.mesh.append(render, &.{
             Vertex{ .pos = .{ -16383, -16383, 0 }, .color = 0xFF0000FF, .uv = .{ 0, 32767 } },
             Vertex{ .pos = .{ 16383, -16383, 0 }, .color = 0xFF00FF00, .uv = .{ 32767, 32767 } },
@@ -185,7 +185,7 @@ pub fn main(init: std.process.Init) !void {
 
     var state: MyState = undefined;
     var engine: ae.Engine = undefined;
-    try engine.init(init.io, memory, .{
+    try engine.init(init.io, init.environ_map, memory, .{
         .memory = .{
             .render = 12 * 1024 * 1024,
             .audio = 10 * 1024 * 1024,


### PR DESCRIPTION
Ship a self-contained CrossCraft-Classic.app on macOS CI:

- Link MoltenVK directly as the Vulkan ICD; skip the Vulkan loader entirely. Feed MoltenVK's vkGetInstanceProcAddr to GLFW via glfwInitVulkanLoader before glfwInit so GLFW never dlopens libvulkan.1.dylib (which is brittle across brew/SDK installs and was the actual cause of VulkanNotSupported on shipped binaries).
- exportArtifact gains a .macos branch that assembles a proper .app tree: exe in Contents/MacOS/, libMoltenVK.dylib + libglfw.3.dylib in Contents/Frameworks/ with @rpath-relative load commands, a minimal Info.plist, optional .icns generated from a source PNG via sips + iconutil, caller-provided resources under Contents/Resources/, and ad-hoc codesign (leaves first, then exe, then bundle; no --deep).
- Add VK_KHR_portability_subset to the mac device-extension list (mandatory per the portability spec when the device advertises it). Skip the loader-only VK_KHR_portability_enumeration instance extension + flag on mac since there's no loader to consume them.

Introduce a cross-platform per-app Dirs abstraction so resource loading and user-state writes stop relying on CWD:

- New Core.paths module with Dirs { resources, data } and a platform-aware resolve() routed through std.Io + the caller's std.process.Environ.Map (no std.c / std.os / std.posix). Per- platform layout:
    macOS:   <Bundle>.app/Contents/Resources/  /  ~/Library/Application Support/<app>/
    Windows: exe dir                           /  %APPDATA%\<app>\
    Linux:   exe dir                           /  $XDG_DATA_HOME/<app>/ (fallback ~/.local/share/<app>/)
    PSP/other: CWD / CWD.
- Engine now owns a Dirs handle; Engine.init takes environ_map and
  an optional app_name and resolves Dirs before anything else.
  Engine.deinit closes them.
- logger.init takes data_dir; Rendering.Texture.load takes a Dir.
  These were the two Aether-side cwd callers.

Add a -Duse-cwd build option that short-circuits Dirs resolution to { cwd, cwd } for dev iteration (zig build run-game), CI smoke tests, and debug builds that want state co-located with the binary.